### PR TITLE
Add CORS headers to response, allowing all origins

### DIFF
--- a/mylog14Dashboard/settings.py
+++ b/mylog14Dashboard/settings.py
@@ -33,6 +33,7 @@ ALLOWED_HOSTS = [
     'localhost'
 ]
 
+CORS_ORIGIN_ALLOW_ALL = True
 
 # Application definition
 
@@ -44,6 +45,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django_celery_results',
+    'corsheaders',
     'rest_framework',
     'api.v1.records',
     'applications.archives'
@@ -52,6 +54,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ coreschema==0.0.4
 cryptography==2.9
 Django==3.0.4
 django-celery-results==1.2.1
+django-cors-headers==3.2.1
 django-filter==2.2.0
 djangorestframework==3.11.0
 gunicorn==20.0.4


### PR DESCRIPTION
# Description

To do a in-browser request to the API (from the App), CORS headers must be added to the response.

# Post-merge actions

A new package `django-cors-headers` is added, so on the deployed instance the command `pip3 install -r requirements.txt` needs to be run again.